### PR TITLE
add_mfa fixing Webull forced MFA issue

### DIFF
--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -56,7 +56,10 @@ class urls :
         return f'{self.base_userbroker_url}/user/warning/v2/query/tickers'
 
     def login(self):
-        return f'{self.base_user_url}/passport/login/account'
+        return f'{self.base_user_url}/passport/login/v3/account'
+
+    def get_mfa(self, account, account_type, device_id, code_type, region_code):
+        return f'{self.base_user_url}/passport/verificationCode/sendCode?account={account}&accountType={account_type}&deviceId={device_id}&codeType={code_type}&regionCode={region_code}'
 
     def logout(self):
         return f'{self.base_userbroker_url}/passport/login/logout'

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -67,7 +67,7 @@ class webull:
         return headers
 
 
-    def login(self, username='', password=''):
+    def login(self, username='', password='', device_name='', mfa=''):
         '''
         Login with email or phone number
 
@@ -93,18 +93,35 @@ class webull:
             'account': username,
             'accountType': accountType,
             'deviceId': self._did,
+            'deviceName': device_name,
+            'extInfo': {'verificationCode': mfa},
+            'grade': 1,
             'pwd': md5_hash.hexdigest(),
+            'regionId': 1
         }
 
-        response = requests.post(self._urls.login(), json=data, headers=self._headers)
+        if mfa != '' :
+            headers = self.build_req_headers()
+        else :
+            headers = self._headers
+        response = requests.post(self._urls.login(), json=data, headers=headers)
         result = response.json()
-        if 'data' in result and 'accessToken' in result['data'] :
-            self._access_token = result['data']['accessToken']
-            self._refresh_token = result['data']['refreshToken']
-            self._token_expire = result['data']['tokenExpireTime']
-            self._uuid = result['data']['uuid']
+        if 'accessToken' in result :
+            self._access_token = result['accessToken']
+            self._refresh_token = result['refreshToken']
+            self._token_expire = result['tokenExpireTime']
+            self._uuid = result['uuid']
             self._account_id = self.get_account_id()
         return result
+
+    def get_mfa(self, username):
+        try:
+          validate_email(username)
+          accountType = 2 # email
+        except EmailNotValidError as _e:
+          accountType = 1 # phone
+        
+        response = requests.get(self._urls.get_mfa(username, str(accountType), str(self._did), str(5), str(1)), headers=self._headers)
 
 
     def login_prompt(self):

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -97,13 +97,13 @@ class webull:
             'accountType': accountType,
             'deviceId': self._did,
             'deviceName': device_name,
-            'extInfo': {'verificationCode': mfa},
             'grade': 1,
             'pwd': md5_hash.hexdigest(),
             'regionId': 1
         }
 
         if mfa != '' :
+            data['extInfo'] = {'verificationCode': mfa}
             headers = self.build_req_headers()
         else :
             headers = self._headers

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -89,6 +89,9 @@ class webull:
         except EmailNotValidError as _e:
           accountType = 1 # phone
 
+        if device_name == '' :
+            device_name = 'default_string'
+
         data = {
             'account': username,
             'accountType': accountType,
@@ -120,7 +123,7 @@ class webull:
           accountType = 2 # email
         except EmailNotValidError as _e:
           accountType = 1 # phone
-        
+
         response = requests.get(self._urls.get_mfa(username, str(accountType), str(self._did), str(5), str(1)), headers=self._headers)
 
 


### PR DESCRIPTION
fixes #47 

```
webull.login(webull_email, webull_pass, 'MacOS Chrome')
webull.get_mfa(webull_email)
webull.login(webull_email, webull_pass, 'MacOS Chrome', '123456')
```
POST
https://userapi.webullbroker.com/api/passport/login/v3/account
account: "test@gmail.com"
accountType: 2
deviceId: "470d8f7f4e32451g80xxxxxb499fddc55"
deviceName: "MacOS Chrome"
extInfo: {verificationCode: "123456"}
grade: 1
pwd: "12345678901234567e912314"
regionId: 1

I am not sure about grade and regionId at this point, if anyone could give it a try.