### PR TITLE
Add lvl two

### DIFF
--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -110,7 +110,7 @@ class urls :
         return f'{self.base_trade_url}/v2/corder/stock/place/{account_id}'
 
     def quotes(self, stock):
-        return f'{self.base_quote_url}/quote/tickerRealTimes/v5/{stock}'
+        return f'{self.base_options_gw_url}/quotes/ticker/getTickerRealTime?tickerId={stock}&includeSecu=1&includeQuote=1'
 
     def rankings(self):
         return f'{self.base_securities_url}/securities/market/v5/6/portal'

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -432,14 +432,12 @@ class webull:
         response = requests.post(self._urls.cancel_otoco_orders(self._account_id), json=data, headers=headers)
         return response.json()
 
-    def get_quote(self, stock=None, tId=None, lvl_two=False) :
+    def get_quote(self, stock=None, tId=None):
         '''
         get price quote
         tId: ticker ID str
         '''
         headers = self.build_req_headers()
-        if lvl_two:
-            headers = self.build_req_headers(include_trade_token=True, include_time=True)
         if not stock and not tId:
             raise ValueError('Must provide a stock symbol or a stock id')
 


### PR DESCRIPTION
Level two quotes are available for logged in subscribers via the get_quote function.  They are found under 'depth' key. #87 

```
>>> from webull import webull
>>> wb = webull()
>>> wb.get_quote('TSLA')
{'tickerId': 913255598, 'exchangeId': 96, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'TESLA', 'symbol': 'TSLA', 'disSymbol': 'TSLA', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NSQ', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2020-08-21T23:59:58.889+0000', 'status': 'A', 'close': '2049.98', 'change': '48.15', 'changeRatio': '0.0241', 'pPrice': '2043.50', 'pChange': '-6.48', 'pChRatio': '-0.0032', 'marketValue': '382037811065.48', 'volume': '21489559', 'turnoverRate': '0.1153', 'timeZone': 'America/New_York', 'tzName': 'EDT', 'preClose': '2001.83', 'open': '2044.76', 'high': '2095.49', 'low': '2025.05', 'vibrateRatio': '0.0349', 'avgVol10D': '18126649', 'avgVol3M': '13682558', 'negMarketValue': '303985939804.58', 'pe': '-420.9318', 'forwardPe': '235.54', 'indicatedPe': '1020.04', 'peTtm': '1054.90', 'eps': '-4.8701', 'epsTtm': '1.943', 'pb': '38.69', 'totalShares': '186361726', 'outstandingShares': '148287271', 'fiftyTwoWkHigh': '2095.49', 'fiftyTwoWkLow': '211.00', 'yield': '0.0000', 'baSize': 0, 'ntvSize': 0, 'currencyCode': 'USD', 'lotSize': '1', 'limitUp': '0.0000', 'limitDown': '0.0000', 'latestDividendDate': '2020-08-31', 'latestEarningsDate': '2020-07-22', 'ps': '15.35', 'bps': '52.98', 'estimateEarningsDate': '10/21-10/26'}
>>> wb.login('foo@gmail.com', 'bar')
>>> wb.get_quote('TSLA')['depth']
{'ntvAggAskList': [{'price': '2044.96', 'volume': '8'}, {'price': '2044.99', 'volume': '1'}, {'price': '2045.00', 'volume': '908'}, {'price': '2045.55', 'volume': '5'}, {'price': '2046.00', 'volume': '6'}, {'price': '2046.98', 'volume': '1'}, {'price': '2049.00', 'volume': '104'}, {'price': '2049.78', 'volume': '2'}, {'price': '2049.90', 'volume': '5'}, {'price': '2049.98', 'volume': '10'}, {'price': '2049.99', 'volume': '4'}, {'price': '2050.00', 'volume': '99'}, {'price': '2051.00', 'volume': '4'}, {'price': '2051.29', 'volume': '10'}, {'price': '2052.99', 'volume': '100'}, {'price': '2053.00', 'volume': '100'}, {'price': '2054.00', 'volume': '5'}, {'price': '2054.77', 'volume': '20'}, {'price': '2054.87', 'volume': '4'}, {'price': '2055.00', 'volume': '1017'}, {'price': '2056.00', 'volume': '40'}, {'price': '2056.45', 'volume': '25'}, {'price': '2057.00', 'volume': '100'}, {'price': '2057.89', 'volume': '1'}, {'price': '2058.00', 'volume': '117'}, {'price': '2058.20', 'volume': '30'}, {'price': '2058.59', 'volume': '1'}, {'price': '2059.00', 'volume': '7'}, {'price': '2059.71', 'volume': '2'}, {'price': '2059.99', 'volume': '1'}], 'ntvAggBidList': [{'price': '2043.00', 'volume': '7'}, {'price': '2042.51', 'volume': '2'}, {'price': '2042.50', 'volume': '1'}, {'price': '2042.00', 'volume': '6'}, {'price': '2041.00', 'volume': '100'}, {'price': '2040.50', 'volume': '5'}, {'price': '2040.20', 'volume': '2'}, {'price': '2040.17', 'volume': '1'}, {'price': '2040.01', 'volume': '5'}, {'price': '2040.00', 'volume': '125'}, {'price': '2039.80', 'volume': '2'}, {'price': '2039.79', 'volume': '1'}, {'price': '2039.21', 'volume': '1'}, {'price': '2038.00', 'volume': '29'}, {'price': '2037.71', 'volume': '3'}, {'price': '2037.50', 'volume': '5'}, {'price': '2037.37', 'volume': '1'}, {'price': '2037.28', 'volume': '5'}, {'price': '2037.00', 'volume': '1'}, {'price': '2036.50', 'volume': '10'}, {'price': '2036.02', 'volume': '5'}, {'price': '2036.00', 'volume': '7'}, {'price': '2035.48', 'volume': '1'}, {'price': '2035.00', 'volume': '185'}, {'price': '2034.99', 'volume': '5'}, {'price': '2034.98', 'volume': '2'}, {'price': '2034.63', 'volume': '1'}, {'price': '2034.16', 'volume': '1'}, {'price': '2034.11', 'volume': '15'}, {'price': '2034.00', 'volume': '33'}]}
>>> wb.get_quote('TSLA')
{'tickerId': 913255598, 'exchangeId': 96, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'TESLA', 'symbol': 'TSLA', 'disSymbol': 'TSLA', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NSQ', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2020-08-21T23:59:58.889+0000', 'status': 'A', 'close': '2049.98', 'change': '48.15', 'changeRatio': '0.0241', 'pPrice': '2043.50', 'pChange': '-6.48', 'pChRatio': '-0.0032', 'marketValue': '382037811065.48', 'volume': '21489559', 'turnoverRate': '0.1153', 'timeZone': 'America/New_York', 'tzName': 'EDT', 'preClose': '2001.83', 'open': '2044.76', 'high': '2095.49', 'low': '2025.05', 'vibrateRatio': '0.0349', 'avgVol10D': '18126649', 'avgVol3M': '13682558', 'negMarketValue': '303985939804.58', 'pe': '-420.9318', 'forwardPe': '235.54', 'indicatedPe': '1020.04', 'peTtm': '1054.90', 'eps': '-4.8701', 'epsTtm': '1.943', 'pb': '38.69', 'totalShares': '186361726', 'outstandingShares': '148287271', 'fiftyTwoWkHigh': '2095.49', 'fiftyTwoWkLow': '211.00', 'yield': '0.0000', 'baSize': 0, 'ntvSize': 30, 'depth': {'ntvAggAskList': [{'price': '2044.96', 'volume': '8'}, {'price': '2044.99', 'volume': '1'}, {'price': '2045.00', 'volume': '908'}, {'price': '2045.55', 'volume': '5'}, {'price': '2046.00', 'volume': '6'}, {'price': '2046.98', 'volume': '1'}, {'price': '2049.00', 'volume': '104'}, {'price': '2049.78', 'volume': '2'}, {'price': '2049.90', 'volume': '5'}, {'price': '2049.98', 'volume': '10'}, {'price': '2049.99', 'volume': '4'}, {'price': '2050.00', 'volume': '99'}, {'price': '2051.00', 'volume': '4'}, {'price': '2051.29', 'volume': '10'}, {'price': '2052.99', 'volume': '100'}, {'price': '2053.00', 'volume': '100'}, {'price': '2054.00', 'volume': '5'}, {'price': '2054.77', 'volume': '20'}, {'price': '2054.87', 'volume': '4'}, {'price': '2055.00', 'volume': '1017'}, {'price': '2056.00', 'volume': '40'}, {'price': '2056.45', 'volume': '25'}, {'price': '2057.00', 'volume': '100'}, {'price': '2057.89', 'volume': '1'}, {'price': '2058.00', 'volume': '117'}, {'price': '2058.20', 'volume': '30'}, {'price': '2058.59', 'volume': '1'}, {'price': '2059.00', 'volume': '7'}, {'price': '2059.71', 'volume': '2'}, {'price': '2059.99', 'volume': '1'}], 'ntvAggBidList': [{'price': '2043.00', 'volume': '7'}, {'price': '2042.51', 'volume': '2'}, {'price': '2042.50', 'volume': '1'}, {'price': '2042.00', 'volume': '6'}, {'price': '2041.00', 'volume': '100'}, {'price': '2040.50', 'volume': '5'}, {'price': '2040.20', 'volume': '2'}, {'price': '2040.17', 'volume': '1'}, {'price': '2040.01', 'volume': '5'}, {'price': '2040.00', 'volume': '125'}, {'price': '2039.80', 'volume': '2'}, {'price': '2039.79', 'volume': '1'}, {'price': '2039.21', 'volume': '1'}, {'price': '2038.00', 'volume': '29'}, {'price': '2037.71', 'volume': '3'}, {'price': '2037.50', 'volume': '5'}, {'price': '2037.37', 'volume': '1'}, {'price': '2037.28', 'volume': '5'}, {'price': '2037.00', 'volume': '1'}, {'price': '2036.50', 'volume': '10'}, {'price': '2036.02', 'volume': '5'}, {'price': '2036.00', 'volume': '7'}, {'price': '2035.48', 'volume': '1'}, {'price': '2035.00', 'volume': '185'}, {'price': '2034.99', 'volume': '5'}, {'price': '2034.98', 'volume': '2'}, {'price': '2034.63', 'volume': '1'}, {'price': '2034.16', 'volume': '1'}, {'price': '2034.11', 'volume': '15'}, {'price': '2034.00', 'volume': '33'}]}, 'currencyCode': 'USD', 'lotSize': '1', 'limitUp': '0.0000', 'limitDown': '0.0000', 'latestDividendDate': '2020-08-31', 'latestEarningsDate': '2020-07-22', 'ps': '15.35', 'bps': '52.98', 'estimateEarningsDate': '10/21-10/26'}
```