### PR TITLE
Add codeAccountType to extInfo in login()

### DIFF
--- a/webull/webull.py
+++ b/webull/webull.py
@@ -113,7 +113,10 @@ class webull:
         }
 
         if mfa != '' :
-            data['extInfo'] = {'verificationCode': mfa}
+            data['extInfo'] = {
+                'codeAccountType': accountType,
+                'verificationCode': mfa
+            }
             headers = self.build_req_headers()
         else :
             headers = self._headers


### PR DESCRIPTION
Webull's login call now requires `codeAccountType` to be included along side `verificationCode` in `extInfo`.
```
"extInfo": {
  "codeAccountType": 2,
  "verificationCode": "420360"
}
```
As of 1/29/2021, the login call will not work without `codeAccountType`.