### PR TITLE
prevent keyerror exception in paper get_account_id

### DIFF
--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1143,7 +1143,7 @@ class paper_webull(webull):
         headers = self.build_req_headers()
         response = requests.get(self._urls.paper_account_id(), headers=headers)
         result = response.json()
-        if result is not None and result[0] is not None:
+        if result is not None and 0 in result:
             id = result[0]['id']
             self._account_id = id
             return id


### PR DESCRIPTION
Checking `result[0]` can result in a `keyError` exception. Using the `in` operator instead, prevents this. This poor practice happens in other locations but this is the spot where it currently affects me.