### PR TITLE
MFA/Security V5 API Endpoint Update Patch - Fixes MFA/Security Logins so that Workaround is no longer needed. 

### DIFF
--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -96,7 +96,6 @@ class urls :
         return f'{self.base_userfintech_url}/user/risk/{url}?account={username}&accountType={account_type}&regionId={region_code}&event={event}&v={time}'
 
     def next_security(self, username, account_type, region_code, event) :
-		    def get_security(self, username, account_type, region_code, event, time, url=0) :
         if url == 1 :
             url = 'nextPrivacyQuestion'
         else :

--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -87,7 +87,7 @@ class urls :
     def check_mfa(self) :
         return f'{self.base_userfintech_url}/passport/v2/verificationCode/checkCode'
 
-	def get_security(self, username, account_type, region_code, event, time, url=0) :
+    def get_security(self, username, account_type, region_code, event, time, url=0) :
         if url == 1 :
             url = 'getPrivacyQuestion'
         else :

--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -82,12 +82,12 @@ class urls :
         return f'{self.base_user_url}/passport/login/v5/account'
 
     def get_mfa(self) :
-        return f'{self.base_userbroker_url}/passport/v2/verificationCode/send'
+        return f'{self.base_userfintech_url}/passport/v2/verificationCode/send'
 
     def check_mfa(self) :
         return f'{self.base_userfintech_url}/passport/v2/verificationCode/checkCode'
 
-    def get_security(self, username, account_type, region_code, event, time, url=0) :
+	def get_security(self, username, account_type, region_code, event, time, url=0) :
         if url == 1 :
             url = 'getPrivacyQuestion'
         else :
@@ -95,7 +95,16 @@ class urls :
 
         return f'{self.base_userfintech_url}/user/risk/{url}?account={username}&accountType={account_type}&regionId={region_code}&event={event}&v={time}'
 
-    def check_security(self) :
+    def next_security(self, username, account_type, region_code, event) :
+		    def get_security(self, username, account_type, region_code, event, time, url=0) :
+        if url == 1 :
+            url = 'nextPrivacyQuestion'
+        else :
+            url = 'nextSecurityQuestion'
+
+        return f'{self.base_userfintech_url}/user/risk/{url}?account={username}&accountType={account_type}&regionId={region_code}&event={event}&v={time}'
+		
+	def check_security(self) :
         return f'{self.base_userfintech_url}/user/risk/checkAnswer'
 
     def logout(self):

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -190,6 +190,25 @@ class webull:
 
         return data
 
+    def next_security(self, username='') :
+        try:
+          validate_email(username)
+          accountType = 2 # email
+        except EmailNotValidError as _e:
+          accountType = 1 # phone
+
+        username = urllib.parse.quote(username)
+        
+        # seems like webull has a bug/stability issue here:
+        time = datetime.now().timestamp() * 1000
+        response = requests.get(self._urls.next_security(username, accountType, self._region_code, 'PRODUCT_LOGIN', time, 0), headers=self._headers)
+        data = response.json()
+        if len(data) == 0 :
+            response = requests.get(self._urls.next_security(username, accountType, self._region_code, 'PRODUCT_LOGIN', time, 1), headers=self._headers)
+            data = response.json()
+
+        return data
+
     def check_security(self, username='', question_id='', question_answer='') :
         try:
           validate_email(username)


### PR DESCRIPTION
Spent several hours probing and Testing mfa and security requests.

get_mfa is being sent to userfintech url instead of userbroker url in V5 API

added next_security api function to be able to request an alternate security question per New V5 API standard.
Use is wb.next_security(email) cell should also work.

Login Request handled:

wb.get_mfa(email)
wb.get_security(email)
wb.login(email, password, anything_you_want, mfa, question_id, question_answer)

too many verification requests in a short time, will block from submiting MFA and Security codes for 60 minutes.

**IF YOU GO TO LOGIN, and you are getting keyerror for SecAccountId: when trying to login using:
data = wb.login(email, password, device, mfa, mfaqid, mfaq) # 6 digits MFA, Security Question ID, Question Answer)
Add:
print(data)
after your data = wb.login line before you try to get account info, you probably failed your validation too many times and are locked out temporarily. Wait at least 1 hour and try again.