### PR TITLE
added options chart data endpoint & function to retrieve bars

### DIFF
--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -113,6 +113,9 @@ class urls :
     def options_exp_date(self, stock):
         return f'{self.base_options_url}/quote/option/{stock}/list'
 
+    def options_bars(self, derivativeId):
+        return f'{self.base_options_gw_url}/quote/option/chart/query?derivativeId={derivativeId}'
+
     def orders(self, account_id, page_size):
         return f'{self.base_trade_url}/v2/option/list?secAccountId={account_id}&startTime=1970-0-1&dateType=ORDER&pageSize={page_size}&status='
 

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1055,7 +1055,7 @@ class webull:
         '''
         headers = self.build_req_headers()
         if derivativeId is None:
-            raise ValueError('Must provide a stock symbol or a stock id')
+            raise ValueError('Must provide derivative ID')
 
         params = {'type': interval, 'count': count, 'timestamp': timeStamp}
         df = DataFrame(columns=['open', 'high', 'low', 'close', 'volume', 'vwap'])

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1051,19 +1051,21 @@ class webull:
             df.loc[to_datetime(datetime.fromtimestamp(int(row[0])).astimezone(time_zone))] = data
         return df.iloc[::-1]
 
-    def get_options_bars(self, derivativeId=None, interval='1m', count=1, timeStamp=None):
+    def get_options_bars(self, derivativeId=None, interval='1m', count=1, direction=1, timeStamp=None):
         '''
         get bars returns a pandas dataframe
         params:
             interval:1m, 5m, 30m, 60m, 1d
             count: number of bars to return
+            direction: 1 ignores {count} parameter & returns all bars on and after timestamp
+                       setting any other value will ignore timestamp & return latest {count} bars
             timeStamp: If epoc timestamp is provided, return bar count up to timestamp. If not set default to current time.
         '''
         headers = self.build_req_headers()
         if derivativeId is None:
             raise ValueError('Must provide derivative ID')
 
-        params = {'type': interval, 'count': count, 'timestamp': timeStamp}
+        params = {'type': interval, 'count': count, 'direction': direction, 'timestamp': timeStamp}
         df = DataFrame(columns=['open', 'high', 'low', 'close', 'volume', 'vwap'])
         df.index.name = 'timestamp'
         response = requests.get(self._urls.options_bars(derivativeId), params=params, headers=headers)


### PR DESCRIPTION
To get a list of options available for a stock, you can simply invoke the `option_chain` function. 
You can retrieve `derivativeIds` for specific options by calling e.g. `option_chain[0]["put"]["tickerId"]`

**data provided is not real-time and has a 15 min delay