### PR TITLE
Fixed accountType typo for login

### DIFF
--- a/webull/webull.py
+++ b/webull/webull.py
@@ -121,7 +121,7 @@ class webull:
 
         if mfa != '' :
             data['extInfo'] = {
-                'codeAccountType': accountType,
+                'codeAccountType': account_type,
                 'verificationCode': mfa
             }
             headers = self.build_req_headers()


### PR DESCRIPTION
A recent pull request (#186) fixed the MFA verification issues. However, it included a typo that prevented the fix from being complete. In particlar, running the `webull.login()` function resulted in an error saying `accountType not defined`. That was because the variable was actually named `acccount_type`. This PR fixes that and, in turn, completes the fix for logging in with new webull accounts!