### PR TITLE
Add get_press_releases and get_calendar_events

### DIFF
--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -15,6 +15,7 @@ class urls :
         self.base_userfintech_url = 'https://userapi.webullfintech.com/api'
         self.base_new_trade_url = 'https://trade.webullfintech.com/api'
         self.base_ustradebroker_url = 'https://ustrade.webullbroker.com/api'
+        self.base_securitiesfintech_url = 'https://securitiesapi.webullfintech.com/api'
 
     def account(self, account_id):
         return f'{self.base_trade_url}/v3/home/{account_id}'
@@ -199,3 +200,12 @@ class urls :
 
     def portfolio_lists(self):
         return f'{self.base_options_gw_url}/personal/portfolio/v2/check'
+    
+    def press_releases(self, stock, typeIds=None, num=50):
+        typeIdsString = ''
+        if typeIds is not None:
+            typeIdsString = '&typeIds=' + typeIds
+        return f'{self.base_securitiesfintech_url}/securities/announcement/{stock}/list?lastAnnouncementId=0&limit={num}{typeIdsString}&options=2'
+
+    def calendar_events(self, event, region_code, start_date, num=50):
+        return f'{self.base_fintech_gw_url}/bgw/explore/calendar/{event}?regionId={region_code}&pageIndex=1&pageSize={num}&startDate={start_date}'

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1278,6 +1278,37 @@ class webull:
         else:
             return True
 
+    def get_press_releases(self, stock=None, tId=None, typeIds=None, num=50):
+        '''
+        gets press releases, useful for getting past earning reports
+        typeIds: None (all) or comma-separated string of the following: '101' (financials) / '104' (insiders)
+        it's possible they add more announcment types in the future, so check the 'announcementTypes'
+        field on the response to verify you have the typeId you want
+        '''
+        if not tId is None:
+            pass
+        elif not stock is None:
+            tId = self.get_ticker(stock)
+        else:
+            raise ValueError('Must provide a stock symbol or a stock id')
+        headers = self.build_req_headers()
+        response = requests.get(self._urls.press_releases(tId, typeIds, num), headers=headers, timeout=self.timeout)
+        result = response.json()
+        return result
+        
+    def get_calendar_events(self, event, start_date=None, num=50):
+        '''
+        gets calendar events
+        event: 'earnings' / 'dividend' / 'splits'
+        start_date: in `YYYY-MM-DD` format, today if None
+        '''
+        if start_date is None:
+            start_date = datetime.today().strftime('%Y-%m-%d')
+        headers = self.build_req_headers()
+        response = requests.get(self._urls.calendar_events(event, self._region_code, start_date, num), headers=headers, timeout=self.timeout)
+        result = response.json()
+        return result
+
 ''' Paper support '''
 class paper_webull(webull):
 


### PR DESCRIPTION
Adds 2 new endpoints:
get_press_releases - gets press releases, useful for getting past earning reports
get_calendar_events - gets upcoming calendar events (earnings, splits, dividends)

Example:
``` Python
releases = wb.get_press_releases("MMM", typeIds='101,104')
print(releases)
```
``` Json
{'announcementTypes': [{'typeId': 101, 'typeName': 'Financials'}, {'typeId': 104, 'typeName': 'Insiders'}], 'announcements': [{'announcementId': 14666253, 'title': '10-Q | 3M CO(0000066740)', 'publishDate': 'Apr 26,2022 13:16', 'language': 'en', 'htmlUrl': 'https://bulletin.webull.com/20220426/169367/7ed4886c9d26f23de80175d5484c6388.html', 'typeName': 'Quarterly report', 'formType': '10-Q'}, {'announcementId': 13364346, 'title': '3/A | 3M CO (0000066740)', 'publishDate': 'Mar 07,2022 16:59', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222008435/xslF345X02/form3a.xml', 'typeName': '[Amend]Initial statement of beneficial ownership of securities', 'formType': '3/A'}, {'announcementId': 13337091, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:03', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005827/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337090, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:08', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005830/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337089, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:13', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005832/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337088, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:17', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005834/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337087, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:21', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005836/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337086, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:25', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005839/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337085, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:30', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005842/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337084, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:34', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005844/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13337083, 'title': '4/A | 3M CO (0000066740)', 'publishDate': 'Feb 22,2022 09:39', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222005846/xslF345X03/form4a.xml', 'typeName': '[Amend]Statement of changes in beneficial ownership of securities', 'formType': '4/A'}, {'announcementId': 13282717, 'title': '3 | 3M CO (0000066740)', 'publishDate': 'Feb 11,2022 10:35', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004398/xslF345X02/form3.xml', 'typeName': 'Initial statement of beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282716, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 11,2022 10:38', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004400/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282735, 'title': '10-K | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 15:13', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000006674022000010/mmm-20211231.htm', 'typeName': 'Annual report', 'formType': '10-K'}, {'announcementId': 13282731, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:26', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004037/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282730, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:30', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004038/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282729, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:30', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004039/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282728, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:33', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004040/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282727, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:33', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004041/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282726, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:36', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004042/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282725, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:37', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004043/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282724, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:38', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004044/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282723, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:39', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004045/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282722, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:39', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004046/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282721, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:42', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004047/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282720, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:43', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004049/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282719, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:45', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004050/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282718, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 09,2022 18:47', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222004051/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282738, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 07,2022 10:44', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222003479/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282737, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 07,2022 10:49', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222003481/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282736, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Feb 07,2022 10:54', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222003485/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282742, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Jan 28,2022 12:49', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222002376/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282741, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Jan 28,2022 12:59', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222002380/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 13282740, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Jan 28,2022 13:02', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222002381/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 12755866, 'title': '3 | 3M CO (0000066740)', 'publishDate': 'Jan 06,2022 15:01', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222001067/xslF345X02/form3.xml', 'typeName': 'Initial statement of beneficial ownership of securities', 'formType': '3'}, {'announcementId': 12755865, 'title': '5 | 3M CO (0000066740)', 'publishDate': 'Jan 06,2022 15:05', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222001070/xslF345X03/form5.xml', 'typeName': 'Annual statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 12755864, 'title': '5 | 3M CO (0000066740)', 'publishDate': 'Jan 06,2022 15:08', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760222001072/xslF345X03/form5.xml', 'typeName': 'Annual statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 12604652, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Dec 02,2021 10:53', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221029993/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 12604653, 'title': '3 | 3M CO (0000066740)', 'publishDate': 'Nov 30,2021 14:36', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221029855/xslF345X02/form3.xml', 'typeName': 'Initial statement of beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678282, 'title': '3 | 3M CO (0000066740)', 'publishDate': 'Nov 05,2021 14:00', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221028437/xslF345X02/form3.xml', 'typeName': 'Initial statement of beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678281, 'title': '3/A | 3M CO (0000066740)', 'publishDate': 'Nov 05,2021 14:49', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221028446/xslF345X02/form3a.xml', 'typeName': '[Amend]Initial statement of beneficial ownership of securities', 'formType': '3/A'}, {'announcementId': 10678280, 'title': '3/A | 3M CO (0000066740)', 'publishDate': 'Nov 05,2021 15:18', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221028450/xslF345X02/form3a.xml', 'typeName': '[Amend]Initial statement of beneficial ownership of securities', 'formType': '3/A'}, {'announcementId': 10678285, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Nov 03,2021 15:55', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221028256/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678284, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Nov 03,2021 16:01', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221028259/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678283, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Nov 03,2021 16:14', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221028267/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678289, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Oct 29,2021 15:36', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221027812/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678288, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Oct 29,2021 15:38', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221027813/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678287, 'title': '4 | 3M CO (0000066740)', 'publishDate': 'Oct 29,2021 15:40', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221027814/xslF345X03/form4.xml', 'typeName': 'Statement of changes in beneficial ownership of securities', 'formType': '3'}, {'announcementId': 10678291, 'title': '10-Q | 3M CO (0000066740)', 'publishDate': 'Oct 26,2021 14:53', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000006674021000013/mmm-20210930.htm', 'typeName': 'Quarterly report', 'formType': '10-Q'}, {'announcementId': 10678290, 'title': '3 | 3M CO (0000066740)', 'publishDate': 'Oct 26,2021 16:17', 'language': 'en', 'htmlUrl': 'https://www.sec.gov/Archives/edgar/data/0000066740/000112760221027646/xslF345X02/form3.xml', 'typeName': 'Initial statement of beneficial ownership of securities', 'formType': '3'}]}
```

``` Python
calendar = wb.get_calendar_events('earnings', '2020-01-01', num=10)
print(calendar)
```
``` Json
{'hasMore': True, 'data': [{'ticker': {'tickerId': 913257433, 'exchangeId': 96, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Landec Corp', 'symbol': 'LNDC', 'disSymbol': 'LNDC', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NSQ', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2022-04-29T20:01:59.943+0000', 'status': 'A', 'close': '9.95', 'change': '-0.24', 'changeRatio': '-0.0236', 'marketValue': '293351253.10', 'volume': '0', 'yield': '0.0000', 'pprice': '9.95', 'pchRatio': '0.0000', 'pchange': '0.00'}, 'values': {'earningReleaseId': 318689, 'tickerId': 913257433, 'regionId': 6, 'qualifier': 'AMC', 'epsEstimate': '-0.0600', 'year': 2020, 'quarter': 'Q2', 'releaseDate': '2020-01-02', 'isLive': True, 'lastReleaseDate': '2019-10-02', 'publishStatus': 1}}, {'ticker': {'tickerId': 913323369, 'exchangeId': 96, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Res Connection', 'symbol': 'RGP', 'disSymbol': 'RGP', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NSQ', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2022-04-29T20:03:36.864+0000', 'status': 'A', 'close': '17.19', 'change': '-0.42', 'changeRatio': '-0.0239', 'marketValue': '569071615.14', 'volume': '0', 'dividend': '0.5600', 'yield': '0.0326', 'pprice': '17.19', 'pchRatio': '0.0000', 'pchange': '0.00'}, 'values': {'earningReleaseId': 318560, 'tickerId': 913323369, 'regionId': 6, 'qualifier': 'AMC', 'epsEstimate': '0.2100', 'year': 2020, 'quarter': 'Q2', 'releaseDate': '2020-01-02', 'isLive': True, 'lastReleaseDate': '2019-10-02', 'lastYear': 2020, 'lastQuarter': 'Q1', 'publishStatus': 1}}, {'ticker': {'tickerId': 925353451, 'exchangeId': 11, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Lamb Weston Hold', 'symbol': 'LW', 'disSymbol': 'LW', 'disExchangeCode': 'NYSE', 'exchangeCode': 'NYSE', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2022-04-29T21:03:54.817+0000', 'status': 'A', 'close': '66.10', 'change': '-1.66', 'changeRatio': '-0.0245', 'marketValue': '9547939098.50', 'volume': '0', 'dividend': '0.9800', 'yield': '0.0148', 'pprice': '66.59', 'pchRatio': '0.0074', 'pchange': '0.49'}, 'values': {'earningReleaseId': 317430, 'tickerId': 925353451, 'regionId': 6, 'qualifier': 'BMO', 'epsEstimate': '0.6140', 'year': 2020, 'quarter': 'Q2', 'releaseDate': '2020-01-03', 'isLive': False, 'lastReleaseDate': '2019-10-02', 'lastYear': 2020, 'lastQuarter': 'Q1', 'publishStatus': 2}}, {'ticker': {'tickerId': 913323701, 'exchangeId': 96, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Hurco Co', 'symbol': 'HURC', 'disSymbol': 'HURC', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NSQ', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 0, 'tradeTime': '2022-04-29T20:00:04.559+0000', 'status': 'B', 'close': '28.37', 'change': '-0.01', 'changeRatio': '-0.0004', 'marketValue': '186590738.28', 'volume': '0', 'dividend': '0.6000', 'yield': '0.0211'}, 'values': {'earningReleaseId': 374675, 'tickerId': 913323701, 'regionId': 6, 'qualifier': 'BMO', 'year': 2019, 'quarter': 'Q4', 'releaseDate': '2020-01-03', 'isLive': False, 'lastReleaseDate': '2019-06-07', 'lastYear': 2019, 'lastQuarter': 'Q2', 'publishStatus': 2}}, {'ticker': {'tickerId': 913324144, 'exchangeId': 112, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Pier 1 Imports', 'symbol': 'PIRRQ', 'disSymbol': 'PIRRQ', 'disExchangeCode': 'No Tier', 'exchangeCode': 'PK', 'listStatus': 3, 'template': 'stock', 'derivativeSupport': 0, 'tradeTime': '2022-04-29T13:30:00.000+0000', 'status': 'B', 'close': '0.1469', 'change': '0.0000', 'changeRatio': '0.00', 'marketValue': '619853.85', 'yield': '0.0000'}, 'values': {'earningReleaseId': 322888, 'tickerId': 913324144, 'regionId': 6, 'qualifier': 'AMC', 'epsEstimate': '-5.1900', 'year': 2020, 'quarter': 'Q3', 'releaseDate': '2020-01-06', 'isLive': False, 'lastReleaseDate': '2019-09-25', 'lastYear': 2020, 'lastQuarter': 'Q2', 'publishStatus': 1}}, {'ticker': {'tickerId': 913256255, 'exchangeId': 96, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Cal Maine Foods Inc', 'symbol': 'CALM', 'disSymbol': 'CALM', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NSQ', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2022-04-29T20:03:06.793+0000', 'status': 'A', 'close': '53.73', 'change': '-1.49', 'changeRatio': '-0.0270', 'marketValue': '2629561405.59', 'volume': '0', 'dividend': '0.0340', 'yield': '0.0006', 'pprice': '53.73', 'pchRatio': '0.0000', 'pchange': '0.00'}, 'values': {'earningReleaseId': 317264, 'tickerId': 913256255, 'regionId': 6, 'qualifier': 'BMO', 'epsEstimate': '0.1900', 'year': 2020, 'quarter': 'Q2', 'releaseDate': '2020-01-06', 'isLive': False, 'lastReleaseDate': '2019-09-30', 'lastYear': 2020, 'lastQuarter': 'Q1', 'publishStatus': 2}}, {'ticker': {'tickerId': 913255100, 'exchangeId': 11, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Commercial Metals Co', 'symbol': 'CMC', 'disSymbol': 'CMC', 'disExchangeCode': 'NYSE', 'exchangeCode': 'NYSE', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2022-04-29T22:23:13.661+0000', 'status': 'A', 'close': '41.00', 'change': '-0.43', 'changeRatio': '-0.0104', 'marketValue': '4981330588.00', 'volume': '0', 'dividend': '0.5600', 'yield': '0.0137', 'pprice': '41.85', 'pchRatio': '0.0207', 'pchange': '0.85'}, 'values': {'earningReleaseId': 315550, 'tickerId': 913255100, 'regionId': 6, 'qualifier': 'BMO', 'epsEstimate': '0.5382', 'year': 2020, 'quarter': 'Q1', 'releaseDate': '2020-01-06', 'isLive': True, 'lastReleaseDate': '2019-10-23', 'lastEps': '0.7600', 'lastYear': 2019, 'lastQuarter': 'Q4', 'publishStatus': 2}}, {'ticker': {'tickerId': 950142224, 'exchangeId': 95, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Q&K International Group Ltd', 'symbol': 'QK', 'disSymbol': 'QK', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NMS', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 0, 'tradeTime': '2022-04-29T20:02:18.313+0000', 'status': 'A', 'close': '0.7800', 'change': '-0.0400', 'changeRatio': '-0.0488', 'marketValue': '8606254.02', 'volume': '0', 'yield': '0.0000', 'pprice': '0.7840', 'pchRatio': '0.0051', 'pchange': '0.0040'}, 'values': {'earningReleaseId': 377304, 'tickerId': 950142224, 'regionId': 6, 'qualifier': 'During The Day', 'eps': '-2.4000', 'year': 2019, 'quarter': 'Q4', 'releaseDate': '2020-01-06', 'isLive': True, 'publishStatus': 3}}, {'ticker': {'tickerId': 913256159, 'exchangeId': 95, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Amarin', 'symbol': 'AMRN', 'disSymbol': 'AMRN', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NMS', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2022-04-29T23:10:26.682+0000', 'status': 'A', 'close': '2.690', 'change': '-0.090', 'changeRatio': '-0.0324', 'marketValue': '1067224711.59', 'volume': '0', 'yield': '0.0000', 'pprice': '2.730', 'pchRatio': '0.0149', 'pchange': '0.040'}, 'values': {'earningReleaseId': 377903, 'tickerId': 913256159, 'regionId': 6, 'qualifier': 'BMO', 'epsEstimate': '-0.0205', 'year': 2019, 'quarter': 'Q4', 'releaseDate': '2020-01-07', 'isLive': False, 'lastReleaseDate': '2019-11-05', 'publishStatus': 2}}, {'ticker': {'tickerId': 913254146, 'exchangeId': 10, 'type': 2, 'secType': [61], 'regionId': 6, 'regionCode': 'US', 'currencyId': 247, 'name': 'Pure Cycle Corp', 'symbol': 'PCYO', 'disSymbol': 'PCYO', 'disExchangeCode': 'NASDAQ', 'exchangeCode': 'NAS', 'listStatus': 1, 'template': 'stock', 'derivativeSupport': 1, 'tradeTime': '2022-04-29T20:14:51.355+0000', 'status': 'A', 'close': '10.45', 'change': '-0.31', 'changeRatio': '-0.0288', 'marketValue': '250366554.90', 'volume': '0', 'yield': '0.0000', 'pprice': '10.45', 'pchRatio': '0.0000', 'pchange': '0.00'}, 'values': {'earningReleaseId': 377165, 'tickerId': 913254146, 'regionId': 6, 'qualifier': 'AMC', 'releaseDate': '2020-01-07', 'isLive': False, 'lastReleaseDate': '2019-11-12', 'lastYear': 2019, 'lastQuarter': 'Q4', 'publishStatus': 1}}], 'tabs': [{'id': 'calendar.earnings', 'type': 'earnings', 'name': 'Earnings', 'checked': True}, {'id': 'calendar.dividend', 'type': 'dividend', 'name': 'Dividends', 'checked': False}, {'id': 'calendar.stockSplit', 'type': 'stockSplit', 'name': 'Splits', 'checked': False}]}
```