### PR TITLE
Add timestamp to get_bars to allow fetching historical data

### DIFF
--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -53,9 +53,9 @@ class urls :
     def analysis_capital_flow(self, stock, show_hist):
         return f'{self.base_securities_url}/wlas/capitalflow/ticker?tickerId={stock}&showHis={show_hist}'
 
-    def bars(self, stock, interval='d1', count=800):
+    def bars(self, stock, interval="d1", count=800, timestamp=None):
         #new
-        return f'{self.base_fintech_gw_url}/quote/charts/query?tickerIds={stock}&type={interval}&count={count}'
+        return f"{self.base_fintech_gw_url}/quote/charts/query?tickerIds={stock}&type={interval}&count={count}&timestamp={timestamp}"
         #old
         return f'{self.base_quote_url}/quote/tickerChartDatas/v5/{stock}'
 

--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -53,9 +53,9 @@ class urls :
     def analysis_capital_flow(self, stock, show_hist):
         return f'{self.base_securities_url}/wlas/capitalflow/ticker?tickerId={stock}&showHis={show_hist}'
 
-    def bars(self, stock, interval="d1", count=800, timestamp=None):
+    def bars(self, stock, interval='d1', count=800, timestamp=None):
         #new
-        return f"{self.base_fintech_gw_url}/quote/charts/query?tickerIds={stock}&type={interval}&count={count}&timestamp={timestamp}"
+        return f'{self.base_fintech_gw_url}/quote/charts/query?tickerIds={stock}&type={interval}&count={count}&timestamp={timestamp}'
         #old
         return f'{self.base_quote_url}/quote/tickerChartDatas/v5/{stock}'
 

--- a/webull/endpoints.py
+++ b/webull/endpoints.py
@@ -53,7 +53,7 @@ class urls :
     def analysis_capital_flow(self, stock, show_hist):
         return f'{self.base_securities_url}/wlas/capitalflow/ticker?tickerId={stock}&showHis={show_hist}'
 
-    def bars(self, stock, interval='d1', count=800, timestamp=None):
+    def bars(self, stock, interval='d1', count=1200, timestamp=None):
         #new
         return f'{self.base_fintech_gw_url}/quote/charts/query?tickerIds={stock}&type={interval}&count={count}&timestamp={timestamp}'
         #old

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1249,7 +1249,7 @@ class webull :
         return df.iloc[::-1]
 
     def get_chart_data(self, stock=None, tId=None, ma=5, timestamp=None):
-        bars = self.get_bars(stock=stock, tId=tId, interval='d1', count=800, timestamp=timestamp)
+        bars = self.get_bars(stock=stock, tId=tId, interval='d1', count=1200, timestamp=timestamp)
         ma_data = bars['close'].rolling(ma).mean()
         return ma_data.dropna()
 

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1247,8 +1247,8 @@ class webull :
             df.loc[to_datetime(datetime.fromtimestamp(int(row[0])).astimezone(time_zone))] = data
         return df.iloc[::-1]
 
-    def get_chart_data(self, stock=None, tId=None, ma=5) :
-        bars = self.get_bars(stock=stock, tId=tId, interval='d1', count=800)
+    def get_chart_data(self, stock=None, tId=None, ma=5, timestamp=None):
+        bars = self.get_bars(stock=stock, tId=tId, interval="d1", count=800, timestamp=timestamp)
         ma_data = bars['close'].rolling(ma).mean()
         return ma_data.dropna()
 

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1145,6 +1145,7 @@ class webull :
             raise ValueError('Must provide a stock symbol or a stock id')
 
         if timeStamp is None:
+            # if not set, default to current time
             timeStamp = int(time.time())
 
         params = {'extendTrading': extendTrading}
@@ -1248,7 +1249,7 @@ class webull :
         return df.iloc[::-1]
 
     def get_chart_data(self, stock=None, tId=None, ma=5, timestamp=None):
-        bars = self.get_bars(stock=stock, tId=tId, interval="d1", count=800, timestamp=timestamp)
+        bars = self.get_bars(stock=stock, tId=tId, interval='d1', count=800, timestamp=timestamp)
         ma_data = bars['close'].rolling(ma).mean()
         return ma_data.dropna()
 

--- a/webull/webull.py
+++ b/webull/webull.py
@@ -1144,10 +1144,18 @@ class webull :
         else:
             raise ValueError('Must provide a stock symbol or a stock id')
 
-        # params = {'type': interval, 'count': count, 'extendTrading': extendTrading, 'timestamp': timeStamp}
+        if timeStamp is None:
+            timeStamp = int(time.time())
+
+        params = {'extendTrading': extendTrading}
         df = DataFrame(columns=['open', 'high', 'low', 'close', 'volume', 'vwap'])
         df.index.name = 'timestamp'
-        response = requests.get(self._urls.bars(tId, interval, count), headers=headers, timeout=self.timeout)
+        response = requests.get(
+            self._urls.bars(tId, interval, count, timeStamp),
+            params=params,
+            headers=headers,
+            timeout=self.timeout,
+        )
         result = response.json()
         time_zone = timezone(result[0]['timeZone'])
         for row in result[0]['data']:


### PR DESCRIPTION
# Description

This PR is to add timestamp and extended hours to **bars** url. Previously this feature has been commented out and not active anymore. Please note that the timestamp argument is dedicated to have integer data type and it's supposed to be unix timestamp. Also it seems that webull increased their capacity in how many data they can return at once from 800 to 1200, changes implied. 

# Tests

Tested locally using postman with GET method and modified URL

# Influence

This PR will affect functions of 
* _get_bars_ 
* _get_chart_data_

While all default value is set and a checker is in place. 

# Date
2022-12-29